### PR TITLE
Fixed problem of getting images.

### DIFF
--- a/wikum/website/parse_helper.py
+++ b/wikum/website/parse_helper.py
@@ -131,7 +131,8 @@ def galleryTagHook(parser_env, body, attributes={}):
                                                                                                   width,
                                                                                                   height)
                 text += '</div></div></div><div class="gallerytext"><p>'
-                if res[1] == 'thumb':
+                if len(res) > 1 and res[1] == 'thumb':
+                    # need to test length because of cases like https://en.wikipedia.org/wiki/Talk:Federal_Assault_Weapons_Ban/Archive_2#RfC:_Is_inclusion_of_the_word_.22cosmetic.22_in_the_Criteria_section_appropriate.3F
                     inner_text = '|'.join(res[2:]).strip()
                 else:
                     inner_text = '|'.join(res[1:]).strip()
@@ -160,7 +161,11 @@ def userHook(parser_env, namespace, body):
 
 def fileHook(parser_env, namespace, body):
     (file_name, pipe, size) = body.partition('|') 
-    
+    size_match = re.search('[1-9][0-9]{0,3}' , size)
+    if size_match:
+        size = size_match.group(0)
+    else:
+        size = '20'
     site = wiki.Wiki('https://en.wikipedia.org/w/api.php')
     params = {'action': 'query', 'titles': 'File:' + file_name,'prop': 'imageinfo', 'iiprop': 'url|thumbmime', 'iiurlwidth': size}
     request = api.APIRequest(site, params)


### PR DESCRIPTION
The format of image information sent seems to differ a lot, causing using regular expression to find the image size.
When no size can be found, set the image size parameter to '20', but this may need fixing.