### PR TITLE
Removed throwing error when no user name is found.

### DIFF
--- a/wikum/website/import_data.py
+++ b/wikum/website/import_data.py
@@ -151,7 +151,14 @@ def import_wiki_sessions(sections, article, reply_to, current_task, total_count)
     return total_count
     
 def import_wiki_authors(authors, article):
-    authors_list = '|'.join(authors)
+    found_authors = []
+    anonymous_exist = False
+    for author in authors:
+        if author:
+            found_authors.append(author)
+        else:
+            anonymous_exist = True
+    authors_list = '|'.join(found_authors)
     
     from wikitools import wiki, api
     domain = article.url.split('/wiki/')[0]
@@ -180,7 +187,10 @@ def import_wiki_authors(authors, article):
         except Exception:
             comment_author = CommentAuthor.objects.create(username=user['name'], is_wikipedia=True)
         comment_authors.append(comment_author)
-        
+
+    if anonymous_exist:
+        comment_authors.append(CommentAuthor.objects.get(disqus_id='anonymous', is_wikipedia=True))
+
     return comment_authors
     
     

--- a/wikum/wikichatter/signatureutils.py
+++ b/wikum/wikichatter/signatureutils.py
@@ -188,7 +188,9 @@ def _extract_rightmost_user(wcode):
     func_picker.extend([(l[0], l[1], _extract_usercontribs_user) for l in uc_locs])
 
     if len(func_picker) == 0:
-        raise NoUsernameError(text)
+        # able to return None because Wikum's code handles it in import_data.py
+        # raise NoUsernameError(text)
+        return None
     (start, end, extractor) = max(func_picker, key=lambda e: e[1])
     user = extractor(text[start:end])
     return user


### PR DESCRIPTION
Although the error thrown in this case is useful for debugging, it prevents complete ingestion of comments.
Returning None is okay because code in import_data.py handles it.