### PR TITLE
'#' should also be treated as same as '*', otherwise indentation beco…

### DIFF
--- a/wikum/wikichatter/indentutils.py
+++ b/wikum/wikichatter/indentutils.py
@@ -100,7 +100,7 @@ def _count_indent_in_some_order(line):
         if len(line) > count and line[count] in indent_chars:
             char = line[count]
             count += _count_leading_char(line[count:], line[count])
-            if char == '*':
+            if char == '*' or char =='#':
                 count_star += count
             indent_chars.remove(char)
         else:


### PR DESCRIPTION
…mes wrong, such as in case of https://en.wikipedia.org/wiki/Wikipedia_talk:Bureaucrats#RfC:_Increasing_the_activity_requirement_for_retaining_bureaucrat_rights

"2.Support..." becomes a reply comment of "1.Support...".
To resolve this treat '#' as same as '*'.